### PR TITLE
Fix Kotlin template hardcoded 'Main'

### DIFF
--- a/cross-platform-kotlin/src/main/resources/archetype-resources/ios/src/main/kotlin/__packageInPathFormat__/__mainClass__.kt
+++ b/cross-platform-kotlin/src/main/resources/archetype-resources/ios/src/main/kotlin/__packageInPathFormat__/__mainClass__.kt
@@ -14,7 +14,7 @@ class ${mainClass} : UIApplicationDelegateAdapter() {
     companion object {
         @JvmStatic fun main(args: Array<String>) {
             val pool = NSAutoreleasePool()
-            UIApplication.main<UIApplication, Main>(args, null, Main::class.java)
+            UIApplication.main<UIApplication, ${mainClass}>(args, null, ${mainClass}::class.java)
             pool.release()
         }
     }


### PR DESCRIPTION
In main function, Main is hardcoded in 2 places. They should match the class name.
